### PR TITLE
Rename exported constants to a longer name, add short unexported names

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ example, for CODATA 2014 load `PhysicalConstants.CODATA2014`:
 ```julia
 julia> using PhysicalConstants.CODATA2014
 
-julia> c
-Speed of light in vacuum (c)
+julia> SpeedOfLightInVacuum
+Speed of light in vacuum (c_0)
 Value                         = 2.99792458e8 m s^-1
 Standard uncertainty          = (exact)
 Relative standard uncertainty = (exact)
 Reference                     = CODATA 2014
 
-julia> G
+julia> NewtonianConstantOfGravitation
 Newtonian constant of gravitation (G)
 Value                         = 6.67408e-11 m^3 kg^-1 s^-2
 Standard uncertainty          = 3.1e-15 m^3 kg^-1 s^-2
@@ -53,18 +53,20 @@ Relative standard uncertainty = 4.6e-5
 Reference                     = CODATA 2014
 ```
 
-`c` and `G` are two of the `Constant`s defined in the
-`PhysicalConstants.CODATA2014` module, the full list of available constants is
-given below.
+`SpeedOfLightInVacuum` and `NewtonianConstantOfGravitation` are two of the
+`Constant`s defined in the `PhysicalConstants.CODATA2014` module, the full list
+of available constants is given below.
 
 `Constant`s can be readily used in mathematical operations, using by default
 their `Float64` value:
 
 ```julia
+julia> import PhysicalConstants.CODATA2014: c_0, ε_0, μ_0
+
 julia> 2 * ε_0
 1.7708375635240778e-11 F m^-1
 
-julia> ε_0 - 1 / (μ_0 * c ^ 2)
+julia> ε_0 - 1 / (μ_0 * c_0 ^ 2)
 0.0 A^2 s^4 kg^-1 m^-3
 ```
 
@@ -81,7 +83,7 @@ julia> float(BigFloat, ε_0)
 julia> big(ε_0)
 8.854187817620389850536563031710750260608370166599449808102417152405395095459979e-12 F m^-1
 
-julia> big(ε_0) - inv(big(μ_0) * big(c)^2)
+julia> big(ε_0) - inv(big(μ_0) * big(c_0)^2)
 0.0 A^2 s^4 kg^-1 m^-3
 ```
 
@@ -92,6 +94,8 @@ the constant, use `measurement(x)`:
 
 ```julia
 julia> using Measurements
+
+julia> import PhysicalConstants.CODATA2014: ħ
 
 julia> measurement(ħ)
 1.0545718001391127e-34 ± 1.2891550390443523e-42 J s
@@ -109,46 +113,59 @@ julia> measurement(BigFloat, ħ) / (measurement(BigFloat, h) / (2 * big(pi)))
 List of Constants
 -----------------
 
-<!-- using PhysicalConstants.CODATA2014, Unitful -->
-<!-- import PhysicalConstants: Constant, name -->
-<!-- symbol(::Constant{sym}) where sym = sym -->
-<!-- println("| Symbol | Name | Value | Unit |") -->
-<!-- println("| ------ | ---- | ----- | ---- |") -->
-<!-- for c in getfield.(Ref(CODATA2014), names(CODATA2014)) -->
-<!--     if c isa Constant -->
-<!--         println("| `", symbol(c), "` | ", name(c), " | ", ustrip(float(c)), " | ", -->
-<!--                 unit(c) == Unitful.NoUnits ? "" : "`$(unit(c))`", " |") -->
-<!--     end -->
-<!-- end -->
+*Note*: each dataset listed below exports by default only the full long names of
+the constants.  Short aliases are provided for convenience, but they are not
+exported, to avoid polluting the main namespace with dozens of short-named
+variables.  Users can to import the short names of the variables they use most
+frequently, as shown in the examples above.
 
-### CODATA 2014
+<!--
+using PhysicalConstants.CODATA2014, Unitful
+import PhysicalConstants: Constant, name
 
-| Symbol | Name                                      | Value                  | Unit             |
-| ------ | ----                                      | -----                  | ----             |
-| `G`    | Newtonian constant of gravitation         | 6.67408e-11            | `m^3 kg^-1 s^-2` |
-| `N_A`  | Avogadro constant                         | 6.022140857e23         | `mol^-1`         |
-| `R`    | Molar gas constant                        | 8.3144598              | `J K^-1 mol^-1`  |
-| `R_∞`  | Rydberg constant                          | 1.0973731568508e7      | `m^-1`           |
-| `Z_0`  | Characteristic impedance of vacuum        | 376.73031346177066     | `Ω`              |
-| `a_0`  | Bohr radius                               | 5.2917721067e-11       | `m`              |
-| `atm`  | Standard atmosphere                       | 101325.0               | `Pa`             |
-| `b`    | Wien wavelength displacement law constant | 0.0028977729           | `K m`            |
-| `c`    | Speed of light in vacuum                  | 2.99792458e8           | `m s^-1`         |
-| `e`    | Elementary charge                         | 1.6021766208e-19       | `C`              |
-| `g_n`  | Standard acceleration of gravitation      | 9.80665                | `m s^-2`         |
-| `h`    | Planck constant                           | 6.62607004e-34         | `J s`            |
-| `k_B`  | Boltzmann constant                        | 1.38064852e-23         | `J K^-1`         |
-| `m_e`  | Electron mass                             | 9.10938356e-31         | `kg`             |
-| `m_n`  | Neutron mass                              | 1.674927471e-27        | `kg`             |
-| `m_p`  | Protron mass                              | 1.672621898e-27        | `kg`             |
-| `m_u`  | Atomic mass constant                      | 1.66053904e-27         | `kg`             |
-| `ħ`    | Planck constant over 2pi                  | 1.0545718001391127e-34 | `J s`            |
-| `α`    | Fine-structure constant                   | 0.0072973525664        |                  |
-| `ε_0`  | Electric constant                         | 8.854187817620389e-12  | `F m^-1`         |
-| `μ_0`  | Magnetic constant                         | 1.2566370614359173e-6  | `N A^-2`         |
-| `μ_B`  | Bohr magneton                             | 9.274009994e-24        | `J T^-1`         |
-| `σ`    | Stefan-Boltzmann constant                 | 5.670367e-8            | `m^2`            |
-| `σ_e`  | Thomson cross section                     | 6.6524587158e-29       | `m^2`            |
+const constants = names(CODATA2014)
+const others = setdiff(names(CODATA2014, all = true), constants)
+
+symbol(::Constant{sym}) where sym = sym
+println("| Long name | Short | Value | Unit |")
+println("| --------- | ----- | ----- | ---- |")
+for c in getfield.(Ref(CODATA2014), constants)
+    if c isa Constant
+        sym = others[findall(x -> c == getfield(CODATA2014, x), others)][1]
+        println("| `", symbol(c), "` | `", sym, "` | ", ustrip(float(c)), " | ",
+                unit(c) == Unitful.NoUnits ? "" : "`$(unit(c))`", " |")
+    end
+end
+-->
+
+### `CODATA2014`
+
+| Long name                               | Short | Value                  | Unit             |
+| ---------                               | ----- | -----                  | ----             |
+| `AtomicMassConstant`                    | `m_u` | 1.66053904e-27         | `kg`             |
+| `AvogadroConstant`                      | `N_A` | 6.022140857e23         | `mol^-1`         |
+| `BohrMagneton`                          | `μ_B` | 9.274009994e-24        | `J T^-1`         |
+| `BohrRadius`                            | `a_0` | 5.2917721067e-11       | `m`              |
+| `BoltzmannConstant`                     | `k_B` | 1.38064852e-23         | `J K^-1`         |
+| `CharacteristicImpedanceOfVacuum`       | `Z_0` | 376.73031346177066     | `Ω`              |
+| `ElectrictConstant`                     | `ε_0` | 8.854187817620389e-12  | `F m^-1`         |
+| `ElectronMass`                          | `m_e` | 9.10938356e-31         | `kg`             |
+| `ElementaryCharge`                      | `e`   | 1.6021766208e-19       | `C`              |
+| `FineStructureConstant`                 | `α`   | 0.0072973525664        |                  |
+| `MagneticConstant`                      | `μ_0` | 1.2566370614359173e-6  | `N A^-2`         |
+| `MolarGasConstant`                      | `R`   | 8.3144598              | `J K^-1 mol^-1`  |
+| `NeutronMass`                           | `m_n` | 1.674927471e-27        | `kg`             |
+| `NewtonianConstantOfGravitation`        | `G`   | 6.67408e-11            | `m^3 kg^-1 s^-2` |
+| `PlanckConstant`                        | `h`   | 6.62607004e-34         | `J s`            |
+| `PlanckConstantOver2pi`                 | `ħ`   | 1.0545718001391127e-34 | `J s`            |
+| `ProtonMass`                            | `m_p` | 1.672621898e-27        | `kg`             |
+| `RydbergConstant`                       | `R_∞` | 1.0973731568508e7      | `m^-1`           |
+| `SpeedOfLightInVacuum`                  | `c_0` | 2.99792458e8           | `m s^-1`         |
+| `StandardAccelerationOfGravitation`     | `g_n` | 9.80665                | `m s^-2`         |
+| `StandardAtmosphere`                    | `atm` | 101325.0               | `Pa`             |
+| `StefanBoltzmannConstant`               | `σ`   | 5.670367e-8            | `m^2`            |
+| `ThomsonCrossSection`                   | `σ_e` | 6.6524587158e-29       | `m^2`            |
+| `WienWavelengthDisplacementLawConstant` | `b`   | 0.0028977729           | `K m`            |
 
 License
 -------

--- a/src/codata2014.jl
+++ b/src/codata2014.jl
@@ -5,84 +5,85 @@ using PhysicalConstants, Measurements, Unitful
 import Unitful: Ω, A, C, F, J, kg, K, m, mol, N, Pa, s, T
 import PhysicalConstants: @constant, @derived_constant
 
-@constant(α, "Fine-structure constant", 7.297_352_5664e-3,
+@constant(FineStructureConstant, α, "Fine-structure constant", 7.297_352_5664e-3,
           BigFloat(72_973_525_664)/BigFloat(10_000_000_000_000), Unitful.NoUnits,
           1.7e-12, BigFloat(17)/BigFloat(10_000_000_000_000), "CODATA 2014")
-@constant(a_0, "Bohr radius", 0.529_177_210_67e-10,
+@constant(BohrRadius, a_0, "Bohr radius", 0.529_177_210_67e-10,
           BigFloat(52_917_721_067)/BigFloat(1_000_000_000_000_000_000_000), m,
           1.2e-20, BigFloat(12)/BigFloat(1_000_000_000_000_000_000_000), "CODATA 2014")
-@constant(atm, "Standard atmosphere", 101_325.0, BigFloat(101_325), Pa,
+@constant(StandardAtmosphere, atm, "Standard atmosphere", 101_325.0, BigFloat(101_325), Pa,
           0.0, BigFloat(0), "CODATA 2014")
-@constant(b, "Wien wavelength displacement law constant", 2.897_7729e-3,
-          BigFloat(28_977_729)/BigFloat(10_000_000_000), m * K,
+@constant(WienWavelengthDisplacementLawConstant, b, "Wien wavelength displacement law constant",
+          2.897_7729e-3, BigFloat(28_977_729)/BigFloat(10_000_000_000), m * K,
           1.7e-9, BigFloat(17)/BigFloat(10_000_000_000), "CODATA 2014")
-@constant(c, "Speed of light in vacuum", 299_792_458.0, BigFloat(299_792_458.0), m / s,
-          0.0, BigFloat(0), "CODATA 2014")
-@constant(µ_0, "Magnetic constant", 1.2566370614359173e-6, 4*big(pi)/BigFloat(10_000_000),
-          N * A^-2, 0.0, BigFloat(0.0), "CODATA 2014")
-@constant(ε_0, "Electric constant", 8.854187817620389e-12,
-          inv(ustrip(big(µ_0)) * ustrip(big(c))^2), F * m^-1,
+@constant(SpeedOfLightInVacuum, c_0, "Speed of light in vacuum", 299_792_458.0,
+          BigFloat(299_792_458.0), m / s, 0.0, BigFloat(0), "CODATA 2014")
+@constant(MagneticConstant, µ_0, "Magnetic constant", 1.2566370614359173e-6,
+          4*big(pi)/BigFloat(10_000_000), N * A^-2, 0.0, BigFloat(0.0),
+          "CODATA 2014")
+@constant(ElectrictConstant, ε_0, "Electric constant", 8.854187817620389e-12,
+          inv(ustrip(big(µ_0)) * ustrip(big(c_0))^2), F * m^-1,
           0.0, BigFloat(0.0), "CODATA 2014")
-@constant(e, "Elementary charge", 1.602_176_6208e-19,
+@constant(ElementaryCharge, e, "Elementary charge", 1.602_176_6208e-19,
           big(16_021_766_208)/100_000_000_000_000_000_000_000_000_000,
           C, 9.8e-28, big(98)/100_000_000_000_000_000_000_000_000_000, "CODATA 2014")
-@constant(G, "Newtonian constant of gravitation", 6.674_08e-11,
-          big(667_408)/big(10_000_000_000_000_000), m^3 * kg^-1 * s^-2,
+@constant(NewtonianConstantOfGravitation, G, "Newtonian constant of gravitation",
+          6.674_08e-11, big(667_408)/big(10_000_000_000_000_000), m^3 * kg^-1 * s^-2,
           3.1e-15, big(31)/big(10_000_000_000_000_000), "CODATA 2014")
-@constant(g_n, "Standard acceleration of gravitation", 9.806_65, big(980_665)/big(100_000),
-          m * s^-2, 0, 0, "CODATA 2014")
-@constant(h, "Planck constant", 6.626_070_040e-34,
+@constant(StandardAccelerationOfGravitation, g_n, "Standard acceleration of gravitation",
+          9.806_65, big(980_665)/big(100_000), m * s^-2, 0, 0, "CODATA 2014")
+@constant(PlanckConstant, h, "Planck constant", 6.626_070_040e-34,
           6_626_070_040/10_000_000_000_000_000_000_000_000_000_000_000_000_000_000,
           J * s, 8.1e-42, 81/10_000_000_000_000_000_000_000_000_000_000_000_000_000_000,
           "CODATA 2014")
-@derived_constant(ħ, "Planck constant over 2pi", 1.0545718001391127e-34,
-                  ustrip(big(h))/(2 * big(pi)), J * s, measurement(h)/2pi,
-                  measurement(BigFloat, h)/(2 * big(pi)), "CODATA 2014")
-@constant(k_B, "Boltzmann constant", 1.380_648_52e-23,
+@derived_constant(PlanckConstantOver2pi, ħ, "Planck constant over 2pi",
+                  1.0545718001391127e-34, ustrip(big(h))/(2 * big(pi)), J * s,
+                  measurement(h)/2pi, measurement(BigFloat, h)/(2 * big(pi)), "CODATA 2014")
+@constant(BoltzmannConstant, k_B, "Boltzmann constant", 1.380_648_52e-23,
           BigFloat(138_064_852)/BigFloat(10_000_000_000_000_000_000_000_000_000_000), J * K^-1,
           7.9e-30, BigFloat(79)/BigFloat(10_000_000_000_000_000_000_000_000_000_000), "CODATA 2014")
-@constant(µ_B, "Bohr magneton", 927.400_9994e-26,
+@constant(BohrMagneton, µ_B, "Bohr magneton", 927.400_9994e-26,
           BigFloat(9274_009_994)/BigFloat(1000_000_000_000_000_000_000_000_000_000_000),
           J * T^-1, 5.7e-32,
           BigFloat(57)/BigFloat(1000_000_000_000_000_000_000_000_000_000_000), "CODATA 2014")
-@constant(m_e, "Electron mass", 9.109_383_56e-31,
+@constant(ElectronMass, m_e, "Electron mass", 9.109_383_56e-31,
           BigFloat(910_938_356)/BigFloat(1000_000_000_000_000_000_000_000_000_000_000_000_000),
           kg, 1.1e-38,
           BigFloat(11)/BigFloat(1000_000_000_000_000_000_000_000_000_000_000_000_000),
           "CODATA 2014")
-@constant(m_n, "Neutron mass", 1.674_927_471e-27,
+@constant(NeutronMass, m_n, "Neutron mass", 1.674_927_471e-27,
           BigFloat(1674_927_471)/BigFloat(1000_000_000_000_000_000_000_000_000_000_000_000),
           kg, 2.1e-35,
           BigFloat(21)/BigFloat(1000_000_000_000_000_000_000_000_000_000_000_000),
           "CODATA 2014")
-@constant(m_p, "Protron mass", 1.672_621_898e-27,
+@constant(ProtonMass, m_p, "Proton mass", 1.672_621_898e-27,
           BigFloat(1672_621_898)/BigFloat(1000_000_000_000_000_000_000_000_000_000_000_000),
           kg, 2.1e-35,
           BigFloat(21)/BigFloat(1000_000_000_000_000_000_000_000_000_000_000_000),
           "CODATA 2014")
-@constant(m_u, "Atomic mass constant", 1.660_539_040e-27,
+@constant(AtomicMassConstant, m_u, "Atomic mass constant", 1.660_539_040e-27,
           BigFloat(1660_539_040)/BigFloat(1000_000_000_000_000_000_000_000_000_000_000_000),
           kg, 2.0e-35,
           BigFloat(20)/BigFloat(1000_000_000_000_000_000_000_000_000_000_000_000),
           "CODATA 2014")
-@constant(N_A, "Avogadro constant", 6.022_140_857e23,
+@constant(AvogadroConstant, N_A, "Avogadro constant", 6.022_140_857e23,
           BigFloat(602_214_085_700_000_000_000_000), mol^-1,
           7.4e15, BigFloat(7_400_000_000_000_000), "CODATA 2014")
-@constant(R, "Molar gas constant", 8.314_4598, BigFloat(8_314_4598)/BigFloat(10_000_000),
+@constant(MolarGasConstant, R, "Molar gas constant", 8.314_4598, BigFloat(8_314_4598)/BigFloat(10_000_000),
           J * mol^-1 * K^-1, 4.8e-6, BigFloat(48)/BigFloat(10_000_000), "CODATA 2014")
-@constant(R_∞, "Rydberg constant", 10_973_731.568_508,
+@constant(RydbergConstant, R_∞, "Rydberg constant", 10_973_731.568_508,
           BigFloat(10_973_731_568_508)/BigFloat(1_000_000), m^-1,
           6.5e-5, BigFloat(65)/BigFloat(1_000_000), "CODATA 2014")
-@constant(σ, "Stefan-Boltzmann constant", 5.670_367e-8,
+@constant(StefanBoltzmannConstant, σ, "Stefan-Boltzmann constant", 5.670_367e-8,
           BigFloat(5670_367)/BigFloat(100_000_000_000_000), m^2,
           1.3e-13, BigFloat(13)/BigFloat(100_000_000_000_000), "CODATA 2014")
-@constant(σ_e, "Thomson cross section", 0.665_245_871_58e-28,
+@constant(ThomsonCrossSection, σ_e, "Thomson cross section", 0.665_245_871_58e-28,
           BigFloat(66_524_587_158)/BigFloat(1000_000_000_000_000_000_000_000_000_000_000_000_000),
           m^2, 9.1e-38,
           BigFloat(91)/BigFloat(1000_000_000_000_000_000_000_000_000_000_000_000_000),
           "CODATA 2014")
-@constant(Z_0, "Characteristic impedance of vacuum", 376.73031346177066,
-          BigFloat(1199_169_832)/BigFloat(10_000_000) * big(pi), Ω,
-          0, BigFloat(0.0), "CODATA 2014")
+@constant(CharacteristicImpedanceOfVacuum, Z_0, "Characteristic impedance of vacuum",
+          376.73031346177066, BigFloat(1199_169_832)/BigFloat(10_000_000) * big(pi), Ω, 0,
+          BigFloat(0.0), "CODATA 2014")
 
-end
+end # module CODATA2014

--- a/src/promotion.jl
+++ b/src/promotion.jl
@@ -1,15 +1,15 @@
-Base.promote_rule(::Type{Constant{sym,S,D,SU}}, ::Type{Quantity{T,D,TU}}) where {sym,S,T,D,SU,TU} =
+Base.promote_rule(::Type{Constant{name,S,D,SU}}, ::Type{Quantity{T,D,TU}}) where {name,S,T,D,SU,TU} =
     promote_type(Quantity{S,D,SU}, Quantity{T,D,TU})
-Base.promote_rule(::Type{Quantity{T,D,TU}}, ::Type{Constant{sym,S,D,SU}}) where {sym,S,T,D,SU,TU} =
+Base.promote_rule(::Type{Quantity{T,D,TU}}, ::Type{Constant{name,S,D,SU}}) where {name,S,T,D,SU,TU} =
     promote_type(Quantity{S,D,SU}, Quantity{T,D,TU})
 
-Base.promote_rule(::Type{Constant{sym,S,NoDims,U}}, ::Type{T}) where {sym,S,U,T<:Number} =
+Base.promote_rule(::Type{Constant{name,S,NoDims,U}}, ::Type{T}) where {name,S,U,T<:Number} =
     promote_type(S, T)
-Base.promote_rule(::Type{Constant{sym,S,NoDims,U}}, ::Type{Quantity{T,NoDims,TU}}) where {sym,S,U,T,TU} =
+Base.promote_rule(::Type{Constant{name,S,NoDims,U}}, ::Type{Quantity{T,NoDims,TU}}) where {name,S,U,T,TU} =
     promote_type(S, T)
 
-Base.convert(::Type{T}, x::Constant{sym,S,NoDims,U}) where {T<:AbstractFloat,sym,S,U} =
+Base.convert(::Type{T}, x::Constant{name,S,NoDims,U}) where {T<:AbstractFloat,name,S,U} =
     float(T, x)
 
-Unitful.uconvert(u::Unitful.Units, c::Constant{sym,T,D,TU}) where {sym,T,D,TU} =
+Unitful.uconvert(u::Unitful.Units, c::Constant{name,T,D,TU}) where {name,T,D,TU} =
     uconvert(u, float(T, c))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,11 @@
 using PhysicalConstants.CODATA2014, Measurements, Unitful
 using Test
 
+import PhysicalConstants.CODATA2014: α, atm, c_0, e, ε_0, h, ħ, µ_0
+
 @testset "Base" begin
     @test ustrip(big(h)) == big"6.626070040e-34"
-    @test setprecision(BigFloat, 768) do; precision(ustrip(big(c))) end == 768
+    @test setprecision(BigFloat, 768) do; precision(ustrip(big(c_0))) end == 768
     @test measurement(h) === measurement(h)
     @test iszero(measurement(α) - measurement(α))
     @test isone(measurement(BigFloat, atm) / measurement(BigFloat, atm))
@@ -12,7 +14,7 @@ using Test
 end
 
 @testset "Promotion" begin
-    x = @inferred(inv(μ_0 * c ^ 2))
+    x = @inferred(inv(μ_0 * c_0 ^ 2))
     T = promote_type(typeof(ε_0), typeof(x))
     u = u"A^2 * kg^-1 * m^-3 * s^4"
     @test promote_type(typeof(α), BigInt) === BigFloat
@@ -20,23 +22,23 @@ end
     @test T === Quantity{Float64, dimension(x), typeof(u)}
     @test convert(T, ε_0) === (ε_0 / unit(ε_0)) * u
     @test convert(Float32, α) === float(Float32, α)
-    @test uconvert(u"cm/s", c) === uconvert(u"cm/s", float(c))
+    @test uconvert(u"cm/s", c_0) === uconvert(u"cm/s", float(c_0))
 end
 
 @testset "Maths" begin
-    @test α ≈ @inferred(e^2/(4 * pi * ε_0 * ħ * c))
+    @test α ≈ @inferred(e^2/(4 * pi * ε_0 * ħ * c_0))
     @test @inferred(α + 2) ≈ 2 + float(α)
     @test @inferred(5 + α) ≈ float(α) + 5
     @test @inferred(α + 2.718) ≈ 2.718 + float(α)
     @test @inferred(-3.14 + α) ≈ float(α) - 3.14
-    @test ε_0 ≈ @inferred(1 / (μ_0 * c ^ 2))
+    @test ε_0 ≈ @inferred(1 / (μ_0 * c_0 ^ 2))
     @test @inferred(big(0) + α) == big(α)
     @test @inferred(α * 1.0) == float(α)
 end
 
 @testset "Show" begin
-    @test repr(c) ==
-        "Speed of light in vacuum (c)
+    @test repr(c_0) ==
+        "Speed of light in vacuum (c_0)
 Value                         = 2.99792458e8 m s^-1
 Standard uncertainty          = (exact)
 Relative standard uncertainty = (exact)
@@ -52,5 +54,11 @@ Reference                     = CODATA 2014"
 Value                         = 1.6021766208e-19 C
 Standard uncertainty          = 9.8e-28 C
 Relative standard uncertainty = 6.1e-9
+Reference                     = CODATA 2014"
+    @test repr(ħ) ==
+        "Planck constant over 2pi (ħ)
+Value                         = 1.0545718001391127e-34 J s
+Standard uncertainty          = 1.2891550390443523e-42 J s
+Relative standard uncertainty = 1.2e-8
 Reference                     = CODATA 2014"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,17 +11,6 @@ using Test
     @test isone(measurement(BigFloat, ħ) / (measurement(BigFloat, h) / 2big(pi)))
 end
 
-@testset "Maths" begin
-    @test α ≈ @inferred(e^2/(4 * pi * ε_0 * ħ * c))
-    @test @inferred(α + 2) ≈ 2 + float(α)
-    @test @inferred(5 + α) ≈ float(α) + 5
-    @test @inferred(α + 2.718) ≈ 2.718 + float(α)
-    @test @inferred(-3.14 + α) ≈ float(α) - 3.14
-    @test ε_0 ≈ @inferred(1 / (μ_0 * c ^ 2))
-    @test @inferred(big(0) + α) == big(α)
-    @test α * 1.0 == float(α)
-end
-
 @testset "Promotion" begin
     x = @inferred(inv(μ_0 * c ^ 2))
     T = promote_type(typeof(ε_0), typeof(x))
@@ -32,4 +21,36 @@ end
     @test convert(T, ε_0) === (ε_0 / unit(ε_0)) * u
     @test convert(Float32, α) === float(Float32, α)
     @test uconvert(u"cm/s", c) === uconvert(u"cm/s", float(c))
+end
+
+@testset "Maths" begin
+    @test α ≈ @inferred(e^2/(4 * pi * ε_0 * ħ * c))
+    @test @inferred(α + 2) ≈ 2 + float(α)
+    @test @inferred(5 + α) ≈ float(α) + 5
+    @test @inferred(α + 2.718) ≈ 2.718 + float(α)
+    @test @inferred(-3.14 + α) ≈ float(α) - 3.14
+    @test ε_0 ≈ @inferred(1 / (μ_0 * c ^ 2))
+    @test @inferred(big(0) + α) == big(α)
+    @test @inferred(α * 1.0) == float(α)
+end
+
+@testset "Show" begin
+    @test repr(c) ==
+        "Speed of light in vacuum (c)
+Value                         = 2.99792458e8 m s^-1
+Standard uncertainty          = (exact)
+Relative standard uncertainty = (exact)
+Reference                     = CODATA 2014"
+    @test repr(α) ==
+        "Fine-structure constant (α)
+Value                         = 0.0072973525664
+Standard uncertainty          = 1.7e-12
+Relative standard uncertainty = 2.3e-10
+Reference                     = CODATA 2014"
+    @test repr(e) ==
+        "Elementary charge (e)
+Value                         = 1.6021766208e-19 C
+Standard uncertainty          = 9.8e-28 C
+Relative standard uncertainty = 6.1e-9
+Reference                     = CODATA 2014"
 end


### PR DESCRIPTION
Fixes #1.