### PR TITLE
Add CODATA2018 set of values

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,16 @@
 name = "PhysicalConstants"
 uuid = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"
 authors = ["Mosè Giordano <mose@gnu.org>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Measurements = "≥ 2.0.0"
+Roots = "≥ 0.8.0"
 Unitful = "≥ 0.15.0"
 julia = "≥ 1.0.0"
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ also be turned into `Measurement` objects (from
 request.
 
 Constants are grouped into different submodules, so that the user can choose
-different datasets as needed.  Currently, only 2014 edition of
+different datasets as needed.  Currently, 2014 and 2018 editions of
 [CODATA](https://physics.nist.gov/cuu/Constants/) recommended values of the
-fundamental physical constants is provided.
+fundamental physical constants are provided.
 
 Installation
 ------------
@@ -38,41 +38,41 @@ Usage
 You can load the package as usual with `using PhysicalConstants` but this module
 does not provide anything useful for the end-users.  You most probably want to
 directly load the submodule with the dataset you are interested in.  For
-example, for CODATA 2014 load `PhysicalConstants.CODATA2014`:
+example, for CODATA 2018 load `PhysicalConstants.CODATA2018`:
 
 ```julia
-julia> using PhysicalConstants.CODATA2014
+julia> using PhysicalConstants.CODATA2018
 
 julia> SpeedOfLightInVacuum
 Speed of light in vacuum (c_0)
 Value                         = 2.99792458e8 m s^-1
 Standard uncertainty          = (exact)
 Relative standard uncertainty = (exact)
-Reference                     = CODATA 2014
+Reference                     = CODATA 2018
 
 julia> NewtonianConstantOfGravitation
 Newtonian constant of gravitation (G)
-Value                         = 6.67408e-11 m^3 kg^-1 s^-2
-Standard uncertainty          = 3.1e-15 m^3 kg^-1 s^-2
-Relative standard uncertainty = 4.6e-5
-Reference                     = CODATA 2014
+Value                         = 6.6743e-11 m^3 kg^-1 s^-2
+Standard uncertainty          = 1.5e-15 m^3 kg^-1 s^-2
+Relative standard uncertainty = 2.2e-5
+Reference                     = CODATA 2018
 ```
 
 `SpeedOfLightInVacuum` and `NewtonianConstantOfGravitation` are two of the
-`Constant`s defined in the `PhysicalConstants.CODATA2014` module, the full list
+`Constant`s defined in the `PhysicalConstants.CODATA2018` module, the full list
 of available constants is given below.
 
 `Constant`s can be readily used in mathematical operations, using by default
 their `Float64` value:
 
 ```julia
-julia> import PhysicalConstants.CODATA2014: c_0, ε_0, μ_0
+julia> import PhysicalConstants.CODATA2018: c_0, ε_0, μ_0
 
 julia> 2 * ε_0
-1.7708375635240778e-11 F m^-1
+1.77083756256e-11 F m^-1
 
 julia> ε_0 - 1 / (μ_0 * c_0 ^ 2)
-0.0 A^2 s^4 kg^-1 m^-3
+-3.8450973786644646e-25 A^2 s^4 kg^-1 m^-3
 ```
 
 If you want to use a different precision for the value of the constant, use the
@@ -83,13 +83,13 @@ julia> float(Float32, ε_0)
 8.854188f-12 F m^-1
 
 julia> float(BigFloat, ε_0)
-8.854187817620389850536563031710750260608370166599449808102417152405395095459979e-12 F m^-1
+8.854187812799999999999999999999999999999999999999999999999999999999999999999973e-12 F m^-1
 
 julia> big(ε_0)
-8.854187817620389850536563031710750260608370166599449808102417152405395095459979e-12 F m^-1
+8.854187812799999999999999999999999999999999999999999999999999999999999999999973e-12 F m^-1
 
 julia> big(ε_0) - inv(big(μ_0) * big(c_0)^2)
-0.0 A^2 s^4 kg^-1 m^-3
+-3.849883307464075736533920296598236938395867709081184624499315166190408485179288e-25 A^2 s^4 kg^-1 m^-3
 ```
 
 Note that `big(constant)` is an alias for `float(BigFloat, constant)`.
@@ -100,16 +100,16 @@ the constant, use `measurement(x)`:
 ```julia
 julia> using Measurements
 
-julia> import PhysicalConstants.CODATA2014: ħ
+julia> import PhysicalConstants.CODATA2018: h, ħ
 
 julia> measurement(ħ)
-1.0545718001391127e-34 ± 1.2891550390443523e-42 J s
+1.0545718176461565e-34 ± 0.0 J s
 
 julia> measurement(Float32, ħ)
-1.0545718e-34 ± 1.289e-42 J s
+1.0545718e-34 ± 0.0 J s
 
 julia> measurement(BigFloat, ħ)
-1.054571800139112651153941068725066773746246506229852090971714108355028066256094e-34 ± 1.289155039044352219727958483317366332479123130497697234856105486877064060837251e-42 J s
+1.054571817646156391262428003302280744722826330020413122421923470598435912734741e-34 ± 0.0 J s
 
 julia> measurement(BigFloat, ħ) / (measurement(BigFloat, h) / (2 * big(pi)))
 1.0 ± 0.0
@@ -126,18 +126,17 @@ frequently, as shown in the examples above.
 
 <!--
 using PhysicalConstants.CODATA2014, Unitful
-import PhysicalConstants: Constant, name
 
 const constants = names(CODATA2014)
 const others = setdiff(names(CODATA2014, all = true), constants)
 
-symbol(::Constant{sym}) where sym = sym
 println("| Long name | Short | Value | Unit |")
 println("| --------- | ----- | ----- | ---- |")
-for c in getfield.(Ref(CODATA2014), constants)
-    if c isa Constant
-        sym = others[findall(x -> c == getfield(CODATA2014, x), others)][1]
-        println("| `", symbol(c), "` | `", sym, "` | ", ustrip(float(c)), " | ",
+for constant in constants
+    c = getfield(CODATA2014, constant)
+    if c isa PhysicalConstants.PhysicalConstant
+        sym = others[findall(x -> c === getfield(CODATA2014, x), others)][1]
+        println("| `", constant, "` | `", sym, "` | ", ustrip(float(c)), " | ",
                 unit(c) == Unitful.NoUnits ? "" : "`$(unit(c))`", " |")
     end
 end
@@ -168,9 +167,38 @@ end
 | `SpeedOfLightInVacuum`                  | `c_0` | 2.99792458e8           | `m s^-1`         |
 | `StandardAccelerationOfGravitation`     | `g_n` | 9.80665                | `m s^-2`         |
 | `StandardAtmosphere`                    | `atm` | 101325.0               | `Pa`             |
-| `StefanBoltzmannConstant`               | `σ`   | 5.670367e-8            | `W m^-2 K^-4`    |
+| `StefanBoltzmannConstant`               | `σ`   | 5.670367e-8            | `W K^-4 m^-2`    |
 | `ThomsonCrossSection`                   | `σ_e` | 6.6524587158e-29       | `m^2`            |
 | `WienWavelengthDisplacementLawConstant` | `b`   | 0.0028977729           | `K m`            |
+
+### `CODATA2018`
+
+| Long name                               | Short | Value                  | Unit             |
+| ---------                               | ----- | -----                  | ----             |
+| `AtomicMassConstant`                    | `m_u` | 1.6605390666e-27       | `kg`             |
+| `AvogadroConstant`                      | `N_A` | 6.02214076e23          | `mol^-1`         |
+| `BohrMagneton`                          | `μ_B` | 9.2740100783e-24       | `J T^-1`         |
+| `BohrRadius`                            | `a_0` | 5.29177210903e-11      | `m`              |
+| `BoltzmannConstant`                     | `k_B` | 1.380649e-23           | `J K^-1`         |
+| `ElectronMass`                          | `m_e` | 9.1093837015e-31       | `kg`             |
+| `ElementaryCharge`                      | `e`   | 1.602176634e-19        | `C`              |
+| `FineStructureConstant`                 | `α`   | 0.0072973525693        |                  |
+| `MolarGasConstant`                      | `R`   | 8.31446261815324       | `J K^-1 mol^-1`  |
+| `NeutronMass`                           | `m_n` | 1.67492749804e-27      | `kg`             |
+| `NewtonianConstantOfGravitation`        | `G`   | 6.6743e-11             | `m^3 kg^-1 s^-2` |
+| `PlanckConstant`                        | `h`   | 6.62607015e-34         | `J s`            |
+| `ProtonMass`                            | `m_p` | 1.67262192369e-27      | `kg`             |
+| `ReducedPlanckConstant`                 | `ħ`   | 1.0545718176461565e-34 | `J s`            |
+| `RydbergConstant`                       | `R_∞` | 1.097373156816e7       | `m^-1`           |
+| `SpeedOfLightInVacuum`                  | `c_0` | 2.99792458e8           | `m s^-1`         |
+| `StandardAccelerationOfGravitation`     | `g_n` | 9.80665                | `m s^-2`         |
+| `StandardAtmosphere`                    | `atm` | 101325.0               | `Pa`             |
+| `StefanBoltzmannConstant`               | `σ`   | 5.6703744191844294e-8  | `W K^-4 m^-2`    |
+| `ThomsonCrossSection`                   | `σ_e` | 6.6524587321e-29       | `m^2`            |
+| `VacuumElectricPermittivity`            | `ε_0` | 8.8541878128e-12       | `F m^-1`         |
+| `VacuumMagneticPermeability`            | `μ_0` | 1.25663706212e-6       | `N A^-2`         |
+| `WienFrequencyDisplacementLawConstant`  | `b′`  | 5.878925757646825e10   | `Hz K^-1`        |
+| `WienWavelengthDisplacementLawConstant` | `b`   | 0.0028977719551851727  | `K m`            |
 
 License
 -------

--- a/src/codata2018.jl
+++ b/src/codata2018.jl
@@ -1,0 +1,109 @@
+module CODATA2018
+
+using PhysicalConstants, Measurements, Unitful, Roots
+
+import Unitful: Ω, A, C, F, Hz, J, kg, K, m, mol, N, Pa, s, T, W
+import PhysicalConstants: @constant, @derived_constant
+
+## Helper functions for the Wien displacement law constants
+_λf(x) = (x - 5) * exp(x) + 5
+_Dλf(x) = (x - 4) * exp(x)
+const _λx0 = 4.965114231744276
+_λx(T) = find_zero((_λf, _Dλf), T(_λx0), Roots.Newton())
+
+_νf(x) = (x - 3) * exp(x) + 3
+_Dνf(x) = (x - 2) * exp(x)
+const _νx0 = 2.8214393721220787
+_νx(T) = find_zero((_νf, _Dνf), T(_νx0), Roots.Newton())
+## end
+
+@constant(FineStructureConstant, α, "Fine-structure constant", 7.297_352_5693e-3,
+          BigFloat(72_973_525_693)/BigFloat(10_000_000_000_000), Unitful.NoUnits,
+          1.1e-12, BigFloat(11)/BigFloat(10_000_000_000_000), "CODATA 2018")
+@constant(BohrRadius, a_0, "Bohr radius", 5.291_772_109_03e-11,
+          BigFloat(529_177_210_903)/BigFloat(10_000_000_000_000_000_000_000), m,
+          8e-21, BigFloat(80)/BigFloat(10_000_000_000_000_000_000_000), "CODATA 2018")
+@constant(StandardAtmosphere, atm, "Standard atmosphere", 101_325.0, BigFloat(101_325), Pa,
+          0.0, BigFloat(0), "CODATA 2018")
+@constant(SpeedOfLightInVacuum, c_0, "Speed of light in vacuum", 299_792_458.0,
+          BigFloat(299_792_458.0), m / s, 0.0, BigFloat(0), "CODATA 2018")
+@constant(VacuumMagneticPermeability, µ_0, "Vacuum magnetic permeability", 1.256_637_062_12e-6,
+          BigFloat(125_663_706_212)/BigFloat(100_000_000_000_000_000), N * A^-2, 1.9e-16,
+          BigFloat(19)/BigFloat(100_000_000_000_000_000), "CODATA 2018")
+@constant(VacuumElectricPermittivity, ε_0, "Vacuum electric permittivity", 8.854_187_8128e-12,
+          BigFloat(88_541_878_128)/BigFloat(10_000_000_000_000_000_000_000), F * m^-1,
+          1.3e-21, BigFloat(13)/BigFloat(10_000_000_000_000_000_000_000), "CODATA 2018")
+@constant(ElementaryCharge, e, "Elementary charge", 1.602_176_634e-19,
+          big(1_602_176_634)/big(10_000_000_000_000_000_000_000_000_000),
+          C, 0.0, BigFloat(0.0), "CODATA 2018")
+@constant(NewtonianConstantOfGravitation, G, "Newtonian constant of gravitation",
+          6.674_30e-11, big(667_430)/big(10_000_000_000_000_000), m^3 * kg^-1 * s^-2,
+          1.5e-15, big(15)/big(10_000_000_000_000_000), "CODATA 2018")
+@constant(StandardAccelerationOfGravitation, g_n, "Standard acceleration of gravitation",
+          9.806_65, big(980_665)/big(100_000), m * s^-2, 0, 0, "CODATA 2018")
+@constant(PlanckConstant, h, "Planck constant", 6.626_070_15e-34,
+          6_626_070_15/1_000_000_000_000_000_000_000_000_000_000_000_000_000_000,
+          J * s, 0.0, BigFloat(0.0), "CODATA 2018")
+@derived_constant(ReducedPlanckConstant, ħ, "Reduced Planck constant",
+                  1.0545718176461565e-34, ustrip(big(h))/(2 * big(pi)), J * s,
+                  measurement(h)/2pi, measurement(BigFloat, h)/(2 * big(pi)), "CODATA 2018")
+@constant(BoltzmannConstant, k_B, "Boltzmann constant", 1.380_649e-23,
+          BigFloat(1_380_649)/BigFloat(100_000_000_000_000_000_000_000_000_000), J * K^-1,
+          0.0, BigFloat(0.0), "CODATA 2018")
+@constant(BohrMagneton, µ_B, "Bohr magneton", 9.274_010_0783e-24,
+          BigFloat(92_740_100_783)/BigFloat(10_000_000_000_000_000_000_000_000_000_000_000),
+          J * T^-1, 2.8e-33,
+          BigFloat(28)/BigFloat(100_00_000_000_000_000_000_000_000_000_000_000), "CODATA 2018")
+@constant(ElectronMass, m_e, "Electron mass", 9.109_383_7015e-31,
+          BigFloat(91_093_837_015)/BigFloat(100_000_000_000_000_000_000_000_000_000_000_000_000_000),
+          kg, 2.8e-40,
+          BigFloat(28)/BigFloat(100_000_000_000_000_000_000_000_000_000_000_000_000_000),
+          "CODATA 2018")
+@constant(NeutronMass, m_n, "Neutron mass", 1.674_927_498_04e-27,
+          BigFloat(167_492_749_804)/BigFloat(100_000_000_000_000_000_000_000_000_000_000_000_000),
+          kg, 9.5e-37,
+          BigFloat(95)/BigFloat(100_000_000_000_000_000_000_000_000_000_000_000_000),
+          "CODATA 2018")
+@constant(ProtonMass, m_p, "Proton mass", 1.672_621_923_69e-27,
+          BigFloat(167_262_192_369)/BigFloat(100_000_000_000_000_000_000_000_000_000_000_000_000),
+          kg, 5.1e-37,
+          BigFloat(51)/BigFloat(100_000_000_000_000_000_000_000_000_000_000_000_000),
+          "CODATA 2018")
+@constant(AtomicMassConstant, m_u, "Atomic mass constant", 1.660_539_066_60e-27,
+          BigFloat(166_053_906_660)/BigFloat(100_000_000_000_000_000_000_000_000_000_000_000_000),
+          kg, 5.0e-37,
+          BigFloat(50)/BigFloat(100_000_000_000_000_000_000_000_000_000_000_000_000),
+          "CODATA 2018")
+@constant(AvogadroConstant, N_A, "Avogadro constant", 6.022_140_76e23,
+          BigFloat(602_214_076_000_000_000_000_000), mol^-1,
+          0.0, BigFloat(0.0), "CODATA 2018")
+@derived_constant(MolarGasConstant, R, "Molar gas constant", 8.314_462_618_153_24,
+                  ustrip(big(N_A) * big(k_B)), J * mol^-1 * K^-1,
+                  measurement(N_A) * measurement(k_B),
+                  measurement(BigFloat, N_A) * measurement(BigFloat, k_B), "CODATA 2018")
+@constant(RydbergConstant, R_∞, "Rydberg constant", 10_973_731.568_160,
+          BigFloat(10_973_731_568_160)/BigFloat(1_000_000), m^-1,
+          2.1e-5, BigFloat(21)/BigFloat(1_000_000), "CODATA 2018")
+@derived_constant(StefanBoltzmannConstant, σ, "Stefan-Boltzmann constant", 5.670_374_419_184_4294e-8,
+                  ustrip(2 * big(pi) ^ 5 * big(k_B) ^ 4 / (15 * big(h) ^ 3 * big(c_0) ^ 2)), W * m^-2 * K^-4,
+                  (2 * pi ^ 5 * measurement(k_B) ^ 4) / (15 * measurement(h) ^ 3 * measurement(c_0) ^ 2),
+                  (2 * big(pi) ^ 5 * measurement(BigFloat, k_B) ^ 4) / (15 * measurement(BigFloat, h) ^ 3 * measurement(BigFloat, c_0) ^ 2),
+                  "CODATA 2018")
+@constant(ThomsonCrossSection, σ_e, "Thomson cross section", 6.652_458_7321e-29,
+          BigFloat(66_524_587_321)/BigFloat(1000_000_000_000_000_000_000_000_000_000_000_000_000),
+          m^2, 6.0e-38,
+          BigFloat(60)/BigFloat(1000_000_000_000_000_000_000_000_000_000_000_000_000),
+          "CODATA 2018")
+@derived_constant(WienWavelengthDisplacementLawConstant, b, "Wien wavelength displacement law constant",
+                  2.897_771_955_185_1727e-3,
+                  ustrip(big(h) * big(c_0) / (_λx(BigFloat) * big(k_B))), m * K,
+                  measurement(h) * measurement(c_0) / (_λx0 * measurement(k_B)),
+                  measurement(BigFloat, h) * measurement(BigFloat, c_0) / (_λx(BigFloat) * measurement(BigFloat, k_B)),
+                  "CODATA 2018")
+@derived_constant(WienFrequencyDisplacementLawConstant, b′, "Wien frequency displacement law constant",
+                  5.878_925_757_646_825e10,
+                  ustrip(_νx(BigFloat) * big(k_B) / big(h)), Hz / K,
+                  _νx0 * measurement(k_B) / measurement(h),
+                  _νx(BigFloat) * measurement(BigFloat, k_B) / measurement(BigFloat, h), "CODATA 2018")
+
+end # module CODATA2018

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,8 @@ end
 end
 
 @testset "Maths" begin
-    @testset for cst in (PhysicalConstants.CODATA2014,)
+    @testset "$cst" for cst in (PhysicalConstants.CODATA2014,
+                                PhysicalConstants.CODATA2018)
         @test cst.α ≈ @inferred(cst.e^2/(4 * cst.pi * cst.ε_0 * cst.ħ * cst.c_0))
         @test @inferred(cst.α + 2) ≈ 2 + float(cst.α)
         @test @inferred(5 + cst.α) ≈ float(cst.α) + 5


### PR DESCRIPTION
Fix #5.

There are still a lot of things to fix and tests are failing badly:

* [x] some constants disappeared (like `CharacteristicImpedanceOfVacuum`), what do to with them?
* [x] some constants are no more exact (like `MagneticConstant` and `ElectricConstant`, which also changed their names)
* [x] `WienWavelengthDisplacementLawConstant` is defined to be exact, but its exact value depends on a special function (see [Wikipedia](https://en.wikipedia.org/w/index.php?title=Wien%27s_displacement_law&oldid=896111537#cite_note-6)). This will be very tricky do deal with in the arbitrary precision case
* [x] more importantly, there is a clash between the constants in the two modules.  I have to fix how the symbols are generated (use `gensym`?)

Resolutions:
* I simply got rid of `CharacteristicImpedanceOfVacuum` in `CODATA2018` as it isn't part of the released set of values, no idea why
* I've renamed the constants that changed their "official" name in the new CODATA dataset.  We may provide backward-compatible aliases in cases users will need them, but for the time being I'd try not to to that
* I've used [`Roots.jl`](https://github.com/JuliaMath/Roots.jl) to numerically compute the the needed constants.  Accuracy is pretty good also with arbitrary precision!
* I've fixed symbol clashing by using `gensym`