### PR TITLE
Fix compatibility issue with `Measurements.jl`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # History of PhysicalConstants.jl
 
+## v0.2.3 (2022-09-01)
+
+### Bug Fixes
+
+* Fixed compatibility issue with `Measurements.jl` v2.8.0 caused by this package
+  using internal functions non part of the public API
+  ([#24](https://github.com/JuliaPhysics/PhysicalConstants.jl/issues/24),
+  [#25](https://github.com/JuliaPhysics/PhysicalConstants.jl/pull/25)).
+
 ## v0.2.2 (2022-08-22)
 
 ### New Features

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PhysicalConstants"
 uuid = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"
 authors = ["Mosè Giordano <mose@gnu.org>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
@@ -9,7 +9,7 @@ Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-Measurements = "2.0.0"
+Measurements = "2.8.0"
 Roots = "0.8.0, 1.0, 2"
 Unitful = "0.15, 0.16, 0.17, 0.18, 1"
 julia = "1.0.0"

--- a/src/PhysicalConstants.jl
+++ b/src/PhysicalConstants.jl
@@ -142,7 +142,7 @@ Reference                     = My lab notebook
 """
 macro constant(name, sym, descr, val, def, unit, unc, bigunc, reference)
     ename, qname, esym, qsym, eunit, _bigconvert = _constant_preamble(name, sym, unit, def)
-    tag = Measurements.tag_counters[Base.Threads.threadid()] += 1
+    tag = Threads.atomic_add!(Measurements.tag_counter, UInt64(1))
     quote
        $(_constant_begin(qname, ename, esym, eunit, val, _bigconvert))
 


### PR DESCRIPTION
`Measurements.jl` recently changed the tag counter from	a vector of counters
indexed by `Threads.threadid()` to a single atomic counter.  This is an internal
detail of the package not part of the public API, but `PhysicalConstants.jl` was
peeking into these details, causing now a compatibility issue.

Fix #24.