### PR TITLE
Define 3-arg `Base.show` for `text/plain` MIME only

### DIFF
--- a/src/PhysicalConstants.jl
+++ b/src/PhysicalConstants.jl
@@ -71,7 +71,7 @@ function _constant_end(qname, ename, qsym, descr, val, reference, eunit)
         Unitful.unit(::PhysicalConstant{_name($ename),T,D,U}) where {T,D,U}      = $eunit
         Unitful.dimension(::PhysicalConstant{_name($ename),T,D,U}) where {T,D,U} = D
 
-        function Base.show(io::IO, x::PhysicalConstant{_name($ename),T,D,U}) where {T,D,U}
+        function Base.show(io::IO, ::MIME"text/plain", x::PhysicalConstant{_name($ename),T,D,U}) where {T,D,U}
             unc = uncertainty(ustrip(measurement($ename)))
             println(io, $descr, " (", $qsym, ")")
             println(io, "Value                         = ", float($ename))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,24 +47,29 @@ end
 end
 
 @testset "Show" begin
+    function plain_repr(x)
+        io = IOBuffer()
+        show(io, "text/plain", x)
+        return String(take!(io))
+    end
     @test occursin(r"Speed of light in vacuum \(c_0\)
 Value                         = 2.99792458e8 m .*
 Standard uncertainty          = \(exact\)
 Relative standard uncertainty = \(exact\)
-Reference                     = CODATA 2014", repr(c_0))
-    @test repr(α) ==
+Reference                     = CODATA 2014", plain_repr(c_0))
+    @test plain_repr(α) ==
         "Fine-structure constant (α)
 Value                         = 0.0072973525664
 Standard uncertainty          = 1.7e-12
 Relative standard uncertainty = 2.3e-10
 Reference                     = CODATA 2014"
-    @test repr(e) ==
+    @test plain_repr(e) ==
         "Elementary charge (e)
 Value                         = 1.6021766208e-19 C
 Standard uncertainty          = 9.8e-28 C
 Relative standard uncertainty = 6.1e-9
 Reference                     = CODATA 2014"
-    @test repr(ħ) ==
+    @test plain_repr(ħ) ==
         "Planck constant over 2pi (ħ)
 Value                         = 1.0545718001391127e-34 J s
 Standard uncertainty          = 1.2891550390443523e-42 J s


### PR DESCRIPTION
```julia-repl
julia> using PhysicalConstants

julia> code_warntype(() -> PhysicalConstants.CODATA2018.G * 2)
MethodInstance for (::var"#1#2")()
  from (::var"#1#2")() @ Main REPL[2]:1
Arguments
  #self#::Core.Const(var"#1#2"())
Body::Unitful.Quantity{Float64, 𝐋^3 𝐌^-1 𝐓^-2, Unitful.FreeUnits{(kg^-1, m^3, s^-2), 𝐋^3 𝐌^-1 𝐓^-2, nothing}}
1 ─ %1 = PhysicalConstants.CODATA2018::Core.Const(PhysicalConstants.CODATA2018)
│   %2 = Base.getproperty(%1, :G)::Core.Const(PhysicalConstants.PhysicalConstant{Symbol("##NewtonianConstantOfGravitation#256"), Float64, 𝐋^3 𝐌^-1 𝐓^-2, Unitful.FreeUnits{(kg^-1, m^3, s^-2), 𝐋^3 𝐌^-1 𝐓^-2, nothing}}())
│   %3 = (%2 * 2)::Core.Const(1.33486e-10 m^3 kg^-1 s^-2)
└──      return %3
```

Fix #28.  CC: @KristofferC