### PR TITLE
Changed "given below" to "given here" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Reference                     = CODATA 2022
 
 `SpeedOfLightInVacuum` and `NewtonianConstantOfGravitation` are two of the
 `PhysicalConstant`s defined in the `PhysicalConstants.CODATA2022` module, the
-full list of available constants is given [here](https://juliaphysics.github.io/PhysicalConstants.jl/stable/constants/).
+[full list of available constants](https://juliaphysics.github.io/PhysicalConstants.jl/stable/constants/) is given in the documentation.
 
 `PhysicalConstant`s can be readily used in mathematical operations, using by
 default their `Float64` value:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Reference                     = CODATA 2022
 
 `SpeedOfLightInVacuum` and `NewtonianConstantOfGravitation` are two of the
 `PhysicalConstant`s defined in the `PhysicalConstants.CODATA2022` module, the
-full list of available constants is given below.
+full list of available constants is given [here](https://juliaphysics.github.io/PhysicalConstants.jl/stable/constants/).
 
 `PhysicalConstant`s can be readily used in mathematical operations, using by
 default their `Float64` value:


### PR DESCRIPTION
Created a link to the full list of physical constants in the documentation since it doesn't seem to be part of the README anymore.