### PR TITLE
Add link to list of constants in documentation

### DIFF
--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -25,7 +25,7 @@ Reference                     = CODATA 2022
 
 `SpeedOfLightInVacuum` and `NewtonianConstantOfGravitation` are two of the
 `PhysicalConstant`s defined in the `PhysicalConstants.CODATA2022` module, the
-full list of available constants is given in the [next section](https://juliaphysics.github.io/PhysicalConstants.jl/stable/constants/).
+full list of available constants is given in [List of Set of Constants](@ref).
 
 `PhysicalConstant`s can be readily used in mathematical operations, using by
 default their `Float64` value:

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -25,7 +25,7 @@ Reference                     = CODATA 2022
 
 `SpeedOfLightInVacuum` and `NewtonianConstantOfGravitation` are two of the
 `PhysicalConstant`s defined in the `PhysicalConstants.CODATA2022` module, the
-full list of available constants is given below.
+full list of available constants is given in the [next section](https://juliaphysics.github.io/PhysicalConstants.jl/stable/constants/).
 
 `PhysicalConstant`s can be readily used in mathematical operations, using by
 default their `Float64` value:


### PR DESCRIPTION
Same fix as #52, but for the documentation page.

However, I don't think this is going to work as-is because that list doesn't exist on `master`?
<img width="680" height="178" alt="image" src="https://github.com/user-attachments/assets/671ed3a9-61d6-4f93-98c8-9cbcb29594ce" />
